### PR TITLE
Fix transparent and sparse images

### DIFF
--- a/network.c
+++ b/network.c
@@ -64,6 +64,8 @@ int net_frame_to_net_frame(struct net_frame* ret, struct img_frame* src, bool mo
 	}
 
 	for (i = 0; i < num_pixels; i++) {
+		cmd = &commands[i];
+		cmd->offset = offset;
 		if(i % 100 >= sparse_perc) {
 			continue;
 		}
@@ -87,8 +89,6 @@ int net_frame_to_net_frame(struct net_frame* ret, struct img_frame* src, bool mo
 			if(print_size < max_print_size) {
 				// First part of command setup
 				// We can't setup .data or .cmd here because data might be realloced
-				cmd = &commands[i];
-				cmd->offset = offset;
 				cmd->length = print_size;
 				offset += print_size;
 				break;


### PR DESCRIPTION
This PR fixes sending transparent images. Previously sturmflut did not work with some (but not all) images containing transparency. This had something to do with the offset for a command not being set when a pixel has alpha which caused the send thread to think it should send 0 pixels.

An example for a previously broken image is attached below:
![cargo](https://github.com/TobleMiner/sturmflut/assets/1557253/dde10533-8aee-4a65-96e0-3bdb3b102f0d)
