### PR TITLE
Fix exiting sturmflut

### DIFF
--- a/network.c
+++ b/network.c
@@ -251,8 +251,8 @@ reconnect:
 			}
 			offset += write_size;
 		}
+		pthread_testcancel();
 		while (net->data_saving && net->current_frame == frame) {
-			pthread_testcancel();
 			usleep(1000);
 		}
 	}


### PR DESCRIPTION
This PR fixes the ability to exit sturmflut if data saving is not enabled.

Previously sturmflut would hang when exiting because the sending threads would never check if they were cancelled when data saving was disabled.