### PR TITLE
Add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 CC=gcc
 CCFLAGS=-Ofast -Wall -march=native
 RM=rm -f
+INSTALL=install
+
 
 MAGICK_VERSION=$(shell pkg-config --modversion ImageMagick | grep -E -o '^[0-9]+')
 
@@ -11,3 +13,6 @@ sturmflut:
 
 clean:
 	$(RM) sturmflut
+
+install: sturmflut
+	$(INSTALL) -Dm755 sturmflut $(DESTDIR)/bin/sturmflut


### PR DESCRIPTION
This PR will add an install target to the Makefile to make installing and packaging sturmflut easier.