### PR TITLE
Fix darwin build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC?=gcc
 CCFLAGS=-Ofast -Wall -march=native
 RM=rm -f
 

--- a/main.c
+++ b/main.c
@@ -14,7 +14,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <sys/sendfile.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
 #include <netdb.h>
 
 #include "main.h"

--- a/network.c
+++ b/network.c
@@ -14,7 +14,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <sys/sendfile.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
 #include <netdb.h>
 #include <assert.h>
 


### PR DESCRIPTION
This PR will fix the sturmflut build for darwin.

Instead of including `sys/sendfile.h` the code now includes `sys/types.h`, `sys/socket.h` and `sys/uio.h` separately which should also work on darwin.

Also the Makefiel is adjusted to use the CC environment variable if it is set. This makes building for darwin easier, as CC is usually set to clang, because there is usually no gcc available on darwin.